### PR TITLE
add static linking as cmake argument for Windows build

### DIFF
--- a/rsocket-rpc-protobuf/CMakeLists.txt
+++ b/rsocket-rpc-protobuf/CMakeLists.txt
@@ -11,6 +11,8 @@ else()
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
 endif()
 
+add_compile_options(/MT$<$<CONFIG:Debug>:d>)
+
 include(FindProtobuf)
 find_package(Protobuf REQUIRED)
 


### PR DESCRIPTION
There was just a missing compiler argument for Windows builds that was causing a static/dynamic linking problem.